### PR TITLE
Refactor CI workflow for linting and building steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,13 @@ on:
     branches: [ main ]
   push: 
     branches: [ main ]
-  
+
+env:
+  GO_VERSION: '1.24'
 
 jobs:
-  build:    
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -19,15 +22,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: '1.24' # You can change this to your desired Go version
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
         with:
           version: latest
-
-      - name: Build
-        run: go build -v ./...
 
       - name: Lint
         run: golangci-lint run
@@ -39,6 +39,24 @@ jobs:
             echo "Code is not properly formatted. Please run 'go fmt ./...'"
             exit 1
           fi
+
+  build-and-test:
+    name: Build and Test
+    needs: lint
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build
+        run: go build -v ./...
 
       - name: Test
         run: go test -v ./...


### PR DESCRIPTION
Separate linting and building steps in the CI workflow and utilize an environment variable for the Go version. This improves clarity and maintainability of the CI process.