### PR TITLE
Changing code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # For more information, see [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax)
 
 # This repository is maintained by: 
-* @chrisreddington
+* @geektrainer


### PR DESCRIPTION
Removing `@chrisreddington` to reduce tags in future PRs and reduce noise, having now left GitHub.